### PR TITLE
Add support for recognition of method names which are operators in sexp_visitor

### DIFF
--- a/lib/skeptic/sexp_visitor.rb
+++ b/lib/skeptic/sexp_visitor.rb
@@ -56,6 +56,7 @@ module Skeptic
           when :const_ref then extract_name(first)
           when :var_ref then extract_name(first)
           when :@const then first
+          when :@op then first
           when :@ident then first
           else '<unknown>'
         end


### PR DESCRIPTION
That fixes some issues, 
e.g. --lines-per-method now can correctly count length of methods even in classes with more than one operator method.
