### PR TITLE
Feature space around operators

### DIFF
--- a/lib/skeptic.rb
+++ b/lib/skeptic.rb
@@ -12,6 +12,7 @@ require 'skeptic/rules/no_semicolons'
 require 'skeptic/rules/line_length'
 require 'skeptic/rules/no_trailing_whitespace'
 require 'skeptic/rules/no_global_variables'
+require 'skeptic/rules/spaces_around_operators'
 
 require 'skeptic/rule_table'
 require 'skeptic/rules'

--- a/lib/skeptic/rules.rb
+++ b/lib/skeptic/rules.rb
@@ -12,5 +12,6 @@ module Skeptic
     table.register NoSemicolons, :boolean
     table.register NoGlobalVariables, :boolean
     table.register NoTrailingWhitespace, :boolean
+    table.register SpacesAroundOperators, :boolean
   end
 end

--- a/lib/skeptic/rules/spaces_around_operators.rb
+++ b/lib/skeptic/rules/spaces_around_operators.rb
@@ -1,0 +1,46 @@
+module Skeptic
+  module Rules
+    class SpacesAroundOperators
+      DESCRIPTION = 'Spaces around operators'
+
+      OPERATORS_WITHOUT_SPACES_AROUND_THEM = ['**']
+
+      def initialize(data)
+        @violations = []
+      end
+
+      def apply_to(code, tokens, sexp)
+        @violations = tokens.each_cons(3).select do |_, token, _|
+          operator_expecting_spaces? token
+        end.select do |left, operator, right|
+          no_spaces_between?(operator, left) or
+          no_spaces_between?(operator, right)
+        end.map do |_, operator, _|
+          [operator.last, operator.first[0]]
+        end
+        self
+      end
+
+      def violations
+        @violations.map do |value, line_number|
+          "no spaces around #{value} on line #{line_number}"
+        end
+      end
+
+      def name
+        'Spaces around operators'
+      end
+
+      private
+
+      def operator_expecting_spaces?(token)
+        token[1] == :on_op and
+          not OPERATORS_WITHOUT_SPACES_AROUND_THEM.include? token.last
+      end
+
+      def no_spaces_between?(operator, neighbour)
+        neighbour.first[0] == operator.first[0] and neighbour[1] != :on_sp
+      end
+    end
+  end
+end

--- a/lib/skeptic/sexp_visitor.rb
+++ b/lib/skeptic/sexp_visitor.rb
@@ -56,6 +56,7 @@ module Skeptic
           when :const_ref then extract_name(first)
           when :var_ref then extract_name(first)
           when :@const then first
+          when :@op then first
           when :@ident then first
           when :@kw then first
           when :@op then first

--- a/spec/skeptic/rules/spaces_around_operators_spec.rb
+++ b/spec/skeptic/rules/spaces_around_operators_spec.rb
@@ -1,0 +1,79 @@
+# encoding: utf-8
+require 'spec_helper'
+
+module Skeptic
+  module Rules
+    describe SpacesAroundOperators do
+      it_behaves_like 'Rule' do
+        subject { SpacesAroundOperators.new(nil) }
+      end
+
+      describe "detecting operators without spaces around them" do
+        it "checks for spaces around operators" do
+          rule = analyze code(<<-RUBY)
+            def s
+              'x'+'z'
+            end
+          RUBY
+
+          rule.should have(1).violations
+          rule.violations.should include 'no spaces around + on line 2'
+        end
+
+        it "checks for spaces left of an operator" do
+          rule = analyze code("2+ d")
+
+          rule.should have(1).violations
+          rule.violations.should include 'no spaces around + on line 1'
+        end
+
+        it "checks for spaces right of an operator" do
+          rule = analyze code("f +z")
+
+          rule.should have(1).violations
+          rule.violations.should include 'no spaces around + on line 1'
+        end
+
+        it "checks for valid operators with spaces around em" do
+          rule = analyze code("pythoh + perl")
+
+          rule.should have(0).violations
+        end
+
+        it "doesnt't check for spaces around **" do
+          rule = analyze code("2 **java")
+
+          rule.should have(0).violations
+        end
+
+        it "checks for multiple operators" do
+          rule = analyze code(<<-RUBY)
+            a = 2 +f
+            b = 4+ g
+            c = x+2+5
+            e = 4
+            f=2+z-z
+          RUBY
+
+          rule.should have(7).violations
+        end
+
+        it "checks once for an operator" do
+          rule = analyze code("2+ z")
+
+          rule.should have(1).violations
+        end
+      end
+
+      describe "reporting" do
+        it "reports under the name 'Spaces around operators'" do
+          SpacesAroundOperators.new(nil).name.should eq 'Spaces around operators'
+        end
+      end
+
+      def analyze(code)
+        apply_rule SpacesAroundOperators, nil, code
+      end
+    end
+  end
+end


### PR DESCRIPTION
Well, add detection for use of operators without space around them(except for `**`, because the style guide encourages `stuff**other`)
