### PR TITLE
Fix issue with passing method chain as block

### DIFF
--- a/lib/skeptic/rules/spaces_around_operators.rb
+++ b/lib/skeptic/rules/spaces_around_operators.rb
@@ -81,6 +81,12 @@ module Skeptic
               mark_special_tokens symbol_location
             when :vcall, :var_ref
               mark_special_tokens block.last.last
+            when :call
+              token = block
+              while token.first == :call
+                token = token[1]
+              end
+              mark_special_tokens token.last.last
           end
         end
       end

--- a/spec/skeptic/rules/spaces_around_operators_spec.rb
+++ b/spec/skeptic/rules/spaces_around_operators_spec.rb
@@ -64,12 +64,14 @@ module Skeptic
 
         it "doesn't check unary operators near brackets" do
           expect_violations_count "{:up => [-1, 1]}", 0
-          expect_violations_count "{-1 => 2}", 0          
+          expect_violations_count "{-1 => 2}", 0
         end
 
         it "doesn't check block arguments" do
           expect_violations_count "a(&b)", 0
           expect_violations_count "def a(&c); end", 0
+          expect_violations_count "a(&b.d)", 0
+          expect_violations_count "a(&b.d.f.e)", 0
         end
 
         it "doesnt't check splat arguments" do


### PR DESCRIPTION
Има проблем със `SpacesAroundOperators` rule-а, когато подаваме chain от методи като блок.

Пример:

`@users.select(&criteria.payment)` не минава проверката за валидност
`@users.select(&payment)` минава проверката за валидност
