### PR TITLE
Fix max arity rule for methods defined outside classes / modules

### DIFF
--- a/lib/skeptic/rules/max_method_arity.rb
+++ b/lib/skeptic/rules/max_method_arity.rb
@@ -43,7 +43,9 @@ module Skeptic
       end
 
       on :def do |name, params, _|
-        qualified_method_name = env[:module] + '#' + extract_name(name)
+        qualified_method_name = extract_name(name)
+        qualified_method_name.prepend(env[:module] + '#') if env[:module]
+
         env.push :method => qualified_method_name
 
         visit params

--- a/spec/skeptic/rules/max_method_arity_spec.rb
+++ b/spec/skeptic/rules/max_method_arity_spec.rb
@@ -10,7 +10,13 @@ module Skeptic
         subject { MaxMethodArity.new }
       end
 
-       describe "limiting method arity" do
+      describe "limiting method arity" do
+        it "works with for method without parameters outside class" do
+          do_not_expect_complaint limit, <<-RUBY
+            def bar; end
+          RUBY
+        end
+
         it "works with for a method without parameters" do
           do_not_expect_complaint limit, <<-RUBY
             class Foo
@@ -61,6 +67,12 @@ module Skeptic
               def foo(x, y); end
               def bar(a, b, c); end
             end
+          RUBY
+        end
+
+        it "catches violations for method outside class" do
+          expect_complaint 1, <<-RUBY
+            def bar(a, b, c); end
           RUBY
         end
 


### PR DESCRIPTION
Проблемен код:

``` ruby
def something(a, b, c, d, e)
end
```

Проблемен rule:
`--max-method-arity 4`

Резултат:

```
/Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:46:in `block in <class:MaxMethodArity>': undefined method `+' for nil:NilClass (NoMethodError)
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `instance_exec'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:44:in `with_sexp_type'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:15:in `apply_to'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/critic.rb:24:in `block in criticize'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:21:in `block in each_rule'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:20:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:20:in `each_rule'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/critic.rb:20:in `criticize'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/bin/skeptic:37:in `criticize_file'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/bin/skeptic:80:in `<top (required)>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/skeptic:23:in `load'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/skeptic:23:in `<main>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `eval'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `<main>'
```
