### PR TITLE
Fix issue with using mixed parameter types

### DIFF
--- a/lib/skeptic/sexp_visitor.rb
+++ b/lib/skeptic/sexp_visitor.rb
@@ -86,7 +86,7 @@ module Skeptic
             [tree]
           when Symbol
             []
-          when nil
+          when nil, false
             []
           else
             tree.compact.map { |node| extract_param_idents node }.reduce [], :+

--- a/spec/skeptic/rules/max_method_arity_spec.rb
+++ b/spec/skeptic/rules/max_method_arity_spec.rb
@@ -91,6 +91,13 @@ module Skeptic
             end
           RUBY
         end
+
+        it "catches violations for methods with mixed positional and keyword arguments" do
+          do_not_expect_complaint 2, <<-RUBY
+            def foo(a, b:)
+            end
+          RUBY
+        end
       end
 
       describe "reporting" do


### PR DESCRIPTION
Проблемен код:

``` ruby
class Foo
  def bar(a, c:)
  end
end
```

Проблемен rule:
`--max-method-arity 4`

Резултат:

```
/Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `extract_param_idents': undefined method `compact' for false:FalseClass (NoMethodError)
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `block in extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `map'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `block in extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `map'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `block in extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `map'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:92:in `extract_param_idents'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:72:in `check_max_arity'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:68:in `block in <class:MaxMethodArity>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `instance_exec'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:44:in `with_sexp_type'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:49:in `block in <class:MaxMethodArity>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `instance_exec'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:44:in `with_sexp_type'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:33:in `block in <class:MaxMethodArity>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `instance_exec'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:44:in `with_sexp_type'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:28:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:33:in `block in visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/sexp_visitor.rb:32:in `visit'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rules/max_method_arity.rb:15:in `apply_to'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/critic.rb:24:in `block in criticize'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:21:in `block in each_rule'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:20:in `each'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/rule_table.rb:20:in `each_rule'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/lib/skeptic/critic.rb:20:in `criticize'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/bin/skeptic:37:in `criticize_file'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/gems/skeptic-0.0.9/bin/skeptic:80:in `<top (required)>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/skeptic:23:in `load'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/skeptic:23:in `<main>'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `eval'
    from /Users/s2gatev/.rvm/gems/ruby-2.1.2/bin/ruby_executable_hooks:15:in `<main>'
```
