### PR TITLE
Unary operators that start lines are not violent

### DIFF
--- a/lib/skeptic/rules/spaces_around_operators.rb
+++ b/lib/skeptic/rules/spaces_around_operators.rb
@@ -9,7 +9,7 @@ module Skeptic
       IGNORED_TOKEN_TYPES = [:on_sp, :on_ignored_nl, :on_nl, :on_lparen, :on_symbeg, :on_lbracket, :on_lbrace]
       LEFT_LIMIT_TOKEN_TYPES = [:on_lparen, :on_lbracket]
       RIGHT_LIMIT_TOKEN_TYPES = [:on_rparen, :on_rbracket]
-      WHITESPACE_TOKEN_TYPES = [:on_sp, :on_nl, :on_ignored_nl]
+      WHITESPACE_TOKEN_TYPES = [:on_sp]
 
       def initialize(data)
         @violations = []
@@ -97,7 +97,7 @@ module Skeptic
         last_significant_token = nil
         tokens.each do |token|
           if token[1] == :on_op
-            if last_significant_token == :on_op
+            if [:on_op, :on_semicolon, :on_ignored_nl].include?(last_significant_token)
               @unary_token_locations << token[0]
             end
             last_significant_token = :on_op

--- a/spec/skeptic/rules/spaces_around_operators_spec.rb
+++ b/spec/skeptic/rules/spaces_around_operators_spec.rb
@@ -111,6 +111,19 @@ module Skeptic
         it "doesnt't report as violations conditions with special unary operators" do
           expect_violations_count '0..-5 || !n.odd?', 0
         end
+
+        it "doesn't report as violations unary operators that start lines" do
+          code = <<-CODE
+def a()
+  !b
+end
+CODE
+          expect_violations_count code, 0
+        end
+
+        it "doesn't report as violations unary operators that follow a ;" do
+          expect_violations_count 'def a(); !b; end', 0
+        end
       end
 
       describe "reporting" do


### PR DESCRIPTION
Skeptic открива нарушение в употребата на празни места около унарния оператор тук:
```ruby
def error?
  !success?
end
```

Според мен горният фрагмент е ok и празно място не трябва да има.