### PR TITLE
Update the Windows installation instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,9 +22,9 @@ You may have to set the following ruby ENV variables. You can do this by adding 
 
 On other Linux/Unix distributions, you are free to use a package manager or another installation method of choice.
 
-For Windows systems, check out [GNU Aspell for Win32](http://aspell.net/win32/). Install Aspell using the "Full Installer" linked in that page, then locate `aspell-15.dll` in the installation and copy it somewhere in your `PATH` as `aspell.dll`.
+For Windows systems, check out [GNU Aspell for Win32](http://aspell.net/win32/). Install Aspell using the "Full Installer" linked in that page, then locate `aspell-15.dll` in the installation (usually in `C:\Program Files (x86)\Aspell\bin`) and copy it in the same folder as `aspell.dll`. After that, add the path to `aspell.dll` in your `PATH` environment variable (again, you'd usually have to add `C:\Program Files (x86)\Aspell\bin`). These instructions have been verified to work with a 32-bit version of Ruby. They might not be applicable to a 64-bit Ruby installation.
 
-**A lot of people miss that**. You need to install an english dictionary from the list in the aspell home page(precompiled dictionaries section). Otherwise aspell will crash with segmentation fault if you try to use the `english-words-for-names' check.  
+**A lot of people miss that**. You need to install an English dictionary from the list in the Aspell home page (precompiled dictionaries section). Otherwise Aspell will crash with segmentation fault if you try to use the `english-words-for-names' check.  
 
 ## Rules
 


### PR DESCRIPTION
I just made a clean installation with a 32-bit Ruby on a Windows 8 system and these were the steps I needed to take in order to get it to work. The old instructions were a bit misleading as copying `aspell.dll` somewhere else in `PATH` leads to problems locating the installed dictionaries – the dicts are looked for in `<DLL path>/../dict` and `<DLL path>/../data` (both folders are needed).

I also capitalized a few names.
